### PR TITLE
Replace windows backslash path with slash

### DIFF
--- a/resources/leiningen/new/exponent/env/dev/user.clj
+++ b/resources/leiningen/new/exponent/env/dev/user.clj
@@ -81,6 +81,7 @@
                                      (if (str/starts-with? % "../../assets")
                                        (-> %
                                            (str/replace "../../" "./")
+                                           (str/replace "\\" "/")
                                            (str/replace "@2x" "")
                                            (str/replace "@3x" ""))
                                        %)
@@ -88,6 +89,7 @@
                      (->> modules
                           (map #(format "(js/require \"%s\")"
                                         (-> %
+                                            (str/replace "\\" "/")
                                             (str/replace "@2x" "")
                                             (str/replace "@3x" ""))))))]
     (try


### PR DESCRIPTION
In Windows, modules path will be like this
```
"\"./assets\images\cljs.png\"" "(js/require \"../../assets\images\cljs.png\")"
```
Which will get error `Unsupported escape character: \i`
So I replace `\` with `/`