### PR TITLE
update template to expo v16

### DIFF
--- a/resources/leiningen/new/exponent/exp.json
+++ b/resources/leiningen/new/exponent/exp.json
@@ -2,7 +2,7 @@
   "name": "{{name}}",
   "description": "No description",
   "slug": "{{name}}",
-  "sdkVersion": "15.0.0",
+  "sdkVersion": "16.0.0",
   "version": "1.0.0",
   "orientation": "portrait",
   "primaryColor": "#cccccc",

--- a/resources/leiningen/new/exponent/package.json
+++ b/resources/leiningen/new/exponent/package.json
@@ -6,8 +6,8 @@
   "private": true,
   "main": "main.js",
   "dependencies": {
-    "expo": "15.0.0",
-    "react": "~15.4.2",
-    "react-native": "github:exponentjs/react-native#sdk-15.0.0"
+    "expo": "^16.0.0",
+      "react": "16.0.0-alpha.6",
+    "react-native": "github:exponentjs/react-native#sdk-16.0.0"
   }
 }


### PR DESCRIPTION
Adjusted as per the documented steps on the expo.io blog:

https://blog.expo.io/expo-sdk-v16-0-0-is-now-available-2151d555a580

But with full disclosure, I am new to exponent, so a more experienced review and/or test is warranted. At the very least, the default code in this template does build and run properly.