### PR TITLE
Windows 10 fixes

### DIFF
--- a/resources/leiningen/new/exponent/env/dev/user.clj
+++ b/resources/leiningen/new/exponent/env/dev/user.clj
@@ -32,7 +32,7 @@
 (defn get-lan-ip
   []
   (cond
-    (= "Mac OS X" (System/getProperty "os.name"))
+    (some #{(System/getProperty "os.name")} ["Mac OS X" "Windows 10"])
     (.getHostAddress (java.net.InetAddress/getLocalHost))
 
     :else
@@ -71,8 +71,8 @@
   (let [modules (->> (file-seq (io/file "assets"))
                      (filter #(and (not (re-find #"DS_Store" (str %)))
                                    (.isFile %)))
-                     (map (fn [file] (when-let [path (str file)]
-                                      (str "../../" path))))
+                     (map (fn [file] (when-let [unix-path (->> file .toPath .iterator iterator-seq (str/join "/"))]
+                                      (str "../../" unix-path))))
                      (concat js-modules ["react" "react-native" "expo"])
                      (distinct))
         modules-map (zipmap


### PR DESCRIPTION
The IP address needs to come from the local host address, just like on
Mac OS X.  Path names need to be specified using forward slashes (like
on UNIX), so that we do not mix forward and backward slashes in the same
path name.