### PR TITLE
Added boot.properties

### DIFF
--- a/resources/leiningen/new/exponent/boot.properties
+++ b/resources/leiningen/new/exponent/boot.properties
@@ -1,0 +1,5 @@
+#http://boot-clj.com
+BOOT_CLOJURE_NAME=org.clojure/clojure
+BOOT_VERSION=2.7.1
+BOOT_CLOJURE_VERSION=1.9.0-alpha10
+BOOT_EMIT_TARGET=no


### PR DESCRIPTION
I didn't investigate too much but this should add a `boot.properties` file to the root folder right? If it does it will fix the issue with `boot dev` failing.

Fixes #27