### PR TITLE
Fix commented js modules still being loaded

### DIFF
--- a/resources/leiningen/new/expo/env/dev/user.clj
+++ b/resources/leiningen/new/expo/env/dev/user.clj
@@ -147,7 +147,7 @@
                                                        (vec))
                                           commented-modules (some->>
                                                               content
-                                                              (re-seq #"[;]+[\s]*\(js/require \"([^\"]+)\"\)")
+                                                              (re-seq #"[;]{2,}.*\(js/require \"([^\"]+)\"\)")
                                                               (map last)
                                                               (set))
                                           js-modules (if commented-modules
@@ -183,7 +183,7 @@
                              (vec))
                 commented-modules (some->>
                                     content
-                                    (re-seq #"[;]+[\s]*\(js/require \"([^\"]+)\"\)")
+                                    (re-seq #"[;]{2,}.*\(js/require \"([^\"]+)\"\)")
                                     (map last)
                                     (set))
                 js-modules (if commented-modules


### PR DESCRIPTION
Currently, commented js modules won't be loaded just when they are not preceded by other functions. For example:

`;; (js/require "react-native")` <-  this won't be loaded
`;; (def ReactNative (js/require "react-native"))` <- this still be loaded
  