### PR TITLE
Use expo's registerRootComponent

### DIFF
--- a/resources/leiningen/new/expo/js/figwheel-bridge.js
+++ b/resources/leiningen/new/expo/js/figwheel-bridge.js
@@ -16,6 +16,7 @@ var config = {
 var React = require('react');
 var createReactClass = require('create-react-class');
 var ReactNative = require('react-native');
+var Expo = require('expo');
 var WebSocket = require('WebSocket');
 var self;
 var evaluate = eval; // This is needed, direct calls to eval does not work (RN packager???)
@@ -219,8 +220,7 @@ function loadApp(platform, devHost, onLoadCb) {
 }
 
 function startApp(appName, platform, devHost) {
-    ReactNative.AppRegistry.registerComponent(
-        appName, () => figwheelApp(platform, devHost));
+    Expo.registerRootComponent(figwheelApp(platform, devHost));
 }
 
 function withModules(moduleById) {

--- a/resources/leiningen/new/expo/om/core.cljs
+++ b/resources/leiningen/new/expo/om/core.cljs
@@ -11,6 +11,7 @@
 (defn create-element [rn-comp opts & children]
       (apply js/React.createElement rn-comp (clj->js opts) children))
 
+(def expo (js/require "expo"))
 (def app-registry (.-AppRegistry ReactNative))
 (def view (partial create-element (.-View ReactNative)))
 (def text (partial create-element (.-Text ReactNative)))
@@ -39,5 +40,5 @@
 (defonce app-root (om/factory RootNode))
 
 (defn init []
-      (om/add-root! state/reconciler AppRoot 1)
-      (.registerComponent app-registry "main" (fn [] app-root)))
+  (om/add-root! state/reconciler AppRoot 1)
+  (.registerRootComponent expo app-root))

--- a/resources/leiningen/new/expo/om/core.cljs
+++ b/resources/leiningen/new/expo/om/core.cljs
@@ -1,6 +1,7 @@
 (ns {{name}}.core
     (:require [om.next :as om :refer-macros [defui]]
               [re-natal.support :as sup]
+              [oops.core :refer [ocall]]
               [{{name}}.state :as state]))
 
 (def logo-img (js/require "./assets/images/cljs.png"))
@@ -41,4 +42,4 @@
 
 (defn init []
   (om/add-root! state/reconciler AppRoot 1)
-  (.registerRootComponent expo app-root))
+  (ocall expo "registerRootComponent" app-root))

--- a/resources/leiningen/new/expo/om/project.clj
+++ b/resources/leiningen/new/expo/om/project.clj
@@ -5,6 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238"]
+                 [binaryage/oops "0.5.8"]
                  [org.omcljs/om "1.0.0-beta1" :exclusions [cljsjs/react cljsjs/react-dom]]
                  [react-native-externs "0.1.0"]]
   :plugins [[lein-cljsbuild "1.1.4"]

--- a/resources/leiningen/new/expo/reagent/core.cljs
+++ b/resources/leiningen/new/expo/reagent/core.cljs
@@ -5,6 +5,7 @@
               [{{name}}.subs]))
 
 (def ReactNative (js/require "react-native"))
+(def expo (js/require "expo"))
 
 (def app-registry (.-AppRegistry ReactNative))
 (def text (r/adapt-react-class (.-Text ReactNative)))
@@ -30,4 +31,4 @@
 
 (defn init []
   (dispatch-sync [:initialize-db])
-  (.registerComponent app-registry "main" #(r/reactify-component app-root)))
+  (.registerRootComponent expo (r/reactify-component app-root)))

--- a/resources/leiningen/new/expo/reagent/core.cljs
+++ b/resources/leiningen/new/expo/reagent/core.cljs
@@ -1,13 +1,13 @@
 (ns {{name}}.core
     (:require [reagent.core :as r :refer [atom]]
               [re-frame.core :refer [subscribe dispatch dispatch-sync]]
+              [oops.core :refer [ocall]]
               [{{name}}.handlers]
               [{{name}}.subs]))
 
 (def ReactNative (js/require "react-native"))
 (def expo (js/require "expo"))
 
-(def app-registry (.-AppRegistry ReactNative))
 (def text (r/adapt-react-class (.-Text ReactNative)))
 (def view (r/adapt-react-class (.-View ReactNative)))
 (def image (r/adapt-react-class (.-Image ReactNative)))
@@ -31,4 +31,4 @@
 
 (defn init []
   (dispatch-sync [:initialize-db])
-  (.registerRootComponent expo (r/reactify-component app-root)))
+  (ocall expo "registerRootComponent" (r/reactify-component app-root)))

--- a/resources/leiningen/new/expo/reagent/project.clj
+++ b/resources/leiningen/new/expo/reagent/project.clj
@@ -5,6 +5,7 @@
                       :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238"]
+                 [binaryage/oops "0.5.8"]
                            [reagent "0.7.0" :exclusions [cljsjs/react cljsjs/react-dom cljsjs/react-dom-server cljsjs/create-react-class]]
                            [re-frame "0.9.3"]
                            [react-native-externs "0.1.0"]]

--- a/resources/leiningen/new/expo/rum/core.cljs
+++ b/resources/leiningen/new/expo/rum/core.cljs
@@ -5,6 +5,7 @@
               [cljs-exponent.components :refer [text view image touchable-highlight] :as rn]))
 
 (def logo-img (js/require "./assets/images/cljs.png"))
+(def expo (js/require "expo"))
 
 (defn alert [title]
   (.alert rn/alert title))
@@ -26,4 +27,4 @@
 
 (defn init []
   (mount-app)
-  (.registerComponent rn/app-registry "main" (fn [] root-component-factory)))
+  (.registerRootComponent expo root-component-factory))

--- a/resources/leiningen/new/expo/rum/core.cljs
+++ b/resources/leiningen/new/expo/rum/core.cljs
@@ -2,6 +2,7 @@
     (:require-macros [rum.core :refer [defc]])
     (:require [re-natal.support :as support]
               [rum.core :as rum]
+              [oops.core :refer [ocall]]
               [cljs-exponent.components :refer [text view image touchable-highlight] :as rn]))
 
 (def logo-img (js/require "./assets/images/cljs.png"))
@@ -27,4 +28,4 @@
 
 (defn init []
   (mount-app)
-  (.registerRootComponent expo root-component-factory))
+  (ocall expo "registerRootComponent" root-component-factory))

--- a/resources/leiningen/new/expo/rum/project.clj
+++ b/resources/leiningen/new/expo/rum/project.clj
@@ -5,6 +5,7 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.238"]
+                 [binaryage/oops "0.5.8"]
                  [rum "0.11.1" :exclusions [cljsjs/react cljsjs/react-dom sablono]]
                  [cljs-exponent "0.1.7"]
                  [sablono "0.8.1-SNAPSHOT"]


### PR DESCRIPTION
I think this should fix #58 (and therefore resolve #46) 

I'm not sure about calling `.registerRootComponent` in advanced builds, though, there might be an externs problem. 

I usually use `ocall` from `cljs-oops` to circumvent this, but I didn't want to import a library to the template unnecessarily. 