### PR TITLE
fix: check ip value before starting

### DIFF
--- a/resources/leiningen/new/expo/env/dev/user.clj
+++ b/resources/leiningen/new/expo/env/dev/user.clj
@@ -68,10 +68,17 @@
            (.getAddress)
            (.getHostAddress)))))
 
-  (defn get-expo-ip []
+(def ip-validator #"\d+\.\d+\.\d+\.\d+")
+
+(defn get-expo-ip []
     (if-let [expo-settings (get-expo-settings)]
       (case (get expo-settings "hostType")
-        "lan" (get-lan-ip)
+        "lan" (let [result (get-lan-ip)]
+                (assert (re-matches ip-validator result)
+                        (str "The found IP " result " is not valid.
+                            Please enter the value manually in the .lan-ip file"))
+                (println "Expo client app will use" result "to connect to the figwheel server")
+                result)
         "localhost" "localhost"
         "tunnel" (throw (Exception. "Expo Setting \"hostType\": \"tunnel\" doesn't work with figwheel. Check .expo/settings.json, please set value to \"lan\" or \"localhost\".")))
       "localhost"))                                         ;; default


### PR DESCRIPTION
While using the expo template we ran into a bug where an ArchLinux machine would not report the ip correctly to the figwheel client, which end up in the figwheel bridge never being able to establish a websocket connection.

We still dont know how to fix that exact piece of code to provide the correct ip but this changes should at least provide more feedback to quickly pinpoint the issue and take measures against it instead of guessing where the problem is.

This PR adds 2 output messages
- one reporting the ip that the expo client will try to use (on start-figwheel)
- an error message displayed whenever the ip doesnt match the defined regular expression. 

@mehdisadeghi since you were the one experiencing this issue it would be great if you could test this in your machine. It seems to work pretty well with my dummy tests.