### PR TITLE
Fix the script on Archlinux

### DIFF
--- a/resources/leiningen/new/expo/lan-ip.sh
+++ b/resources/leiningen/new/expo/lan-ip.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo `ip route get 8.8.8.8 | awk '{print $NF; exit}'` > .lan-ip
+echo `ip route get 8.8.8.8 | head -n 1 | cut -d ' ' -f 7` > .lan-ip

--- a/resources/leiningen/new/expo/lan-ip.sh
+++ b/resources/leiningen/new/expo/lan-ip.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo `ip route get 8.8.8.8 | head -n 1 | cut -d ' ' -f 7` > .lan-ip
+echo `ip route get 8.8.8.8 | head -n 1 | tr -s ' ' | cut -d ' ' -f 7` > .lan-ip


### PR DESCRIPTION
The script used to get the IP address returns the wrong IP on Archlinux:

    $ echo `ip route get 8.8.8.8 | awk '{print $NF; exit}'`
    1000

Because the output of `ip route` is different:

    $ ip route get 8.8.8.8
    8.8.8.8 via 192.168.1.1 dev wlp3s0 src 192.168.1.225 uid 1000 
        cache

This PR is also related to #69.