### PR TITLE
Filter out virbr network interface when looking up lan ip

### DIFF
--- a/resources/leiningen/new/expo/env/dev/user.clj
+++ b/resources/leiningen/new/expo/env/dev/user.clj
@@ -51,7 +51,8 @@
       (->> (java.net.NetworkInterface/getNetworkInterfaces)
            (enumeration-seq)
            (filter #(not (or (str/starts-with? (.getName %) "docker")
-                             (str/starts-with? (.getName %) "br-"))))
+                             (str/starts-with? (.getName %) "br-")
+                             (str/starts-with? (.getName %) "virbr"))))
            (map #(.getInterfaceAddresses %))
            (map
              (fn [ip]


### PR DESCRIPTION
`virbr` is a network interface that is provided by the `libvirt` library. It needs to be filtered out in the case of it being installed. Fail to do so and figwheel won't be able to connect to your device while developing.